### PR TITLE
Updated ShipPlanner.java

### DIFF
--- a/src/main/java/com/battleship/gui/ShipPlanner.java
+++ b/src/main/java/com/battleship/gui/ShipPlanner.java
@@ -212,7 +212,7 @@ public class ShipPlanner implements ActionListener {
             // TODO: refactor
             for (int i = 0; i < 10; i++) {
                 for (int j = 0; j < 10; j++) {
-                    if (source == positions[i][j]) {
+                    if (source == positions[i][j] && isValidPosition(i, j, i, j)) {
 
                         int comboBoxItemCount = comboBoxShipSelector.getItemCount();
 


### PR DESCRIPTION
Update at line 215, we only care about recording actions from MouseListener, so I added another check to make sure that the location is valid. This way, if we click a spot we already clicked with one ship left, the "OK" button won't turn active.