### PR TITLE
Update ShipPlanner.java

### DIFF
--- a/src/main/java/com/battleship/gui/ShipPlanner.java
+++ b/src/main/java/com/battleship/gui/ShipPlanner.java
@@ -214,7 +214,7 @@ public class ShipPlanner implements ActionListener {
             // TODO: refactor
             for (int i = 0; i < 10; i++) {
                 for (int j = 0; j < 10; j++) {
-                    if (source == positions[i][j] && isValidPosition(i, y, i, y)) {
+                    if (source == positions[i][j] && isValidPosition(i, j, i, j)) {
 
                         int comboBoxItemCount = comboBoxShipSelector.getItemCount();
 

--- a/src/main/java/com/battleship/gui/ShipPlanner.java
+++ b/src/main/java/com/battleship/gui/ShipPlanner.java
@@ -214,7 +214,7 @@ public class ShipPlanner implements ActionListener {
             // TODO: refactor
             for (int i = 0; i < 10; i++) {
                 for (int j = 0; j < 10; j++) {
-                    if (source == positions[i][j]) {
+                    if (source == positions[i][j] && isValidPosition(i, y, i, y)) {
 
                         int comboBoxItemCount = comboBoxShipSelector.getItemCount();
 


### PR DESCRIPTION
Updated line 217, this is to address the error where a player can start the game without placing their last ship. This error was replicable by using either mouse button to click on an existing ship or its surroundings. These placements are invalid, but you could press the Ok button afterward. I fixed this by adding an additional "isValidPosition" check whenever a press is done, and only progressing forward if the click is in a valid location.