### PR TITLE
Update ShipPlanner.java

### DIFF
--- a/src/main/java/com/battleship/gui/ShipPlanner.java
+++ b/src/main/java/com/battleship/gui/ShipPlanner.java
@@ -214,7 +214,7 @@ public class ShipPlanner implements ActionListener {
             // TODO: refactor
             for (int i = 0; i < 10; i++) {
                 for (int j = 0; j < 10; j++) {
-                    if (source == positions[i][j]) {
+                    if (source == positions[i][j] && isValidPosition(i,j,i,j)) {
 
                         int comboBoxItemCount = comboBoxShipSelector.getItemCount();
 


### PR DESCRIPTION
This push is to fix the error that a player can start the game without placing their last ship. This is done by clicking anywhere a ship cannot be placed. I fixed this by adding a check in line 217, checking if the mouseclick is a valid location, and only recording the action if it is valid.