### PR TITLE
Update GameBoard.java

### DIFF
--- a/src/main/java/com/battleship/gui/GameBoard.java
+++ b/src/main/java/com/battleship/gui/GameBoard.java
@@ -211,6 +211,8 @@ public class GameBoard {
                 enemyPositions[posToAttack[1]][posToAttack[2]].setBackground(Color.RED);
                 setPlayerTurn(true);
             } else if (posToAttack[0] == GAME_WON) {
+                //Player has won, set the position to be red and display victory message
+                enemyPositions[posToAttack[1]][posToAttack[2]].setBackground(Color.RED);
                 JOptionPane.showMessageDialog(frame,
                         "You won!",
                         "Congratulations",


### PR DESCRIPTION
Addressed the issue where the last successful hit wouldn't change to the correct color, turning orange instead of red. This was resolved by manually setting the color of the last position to red before displaying the message. In the original code, when someone got a correct hit, the tile would turn red. The problem stemmed from this code turning the tile red wouldn't occur when someone won due to the if-else structure of this part of the code. As such, manually setting the tile to red when displaying the victory screen resolves this issue.